### PR TITLE
fix over-flattening by List.flatten in Chunk.map_parallel

### DIFF
--- a/lib/paratize/chunk.ex
+++ b/lib/paratize/chunk.ex
@@ -31,7 +31,7 @@ defmodule Paratize.Chunk do
       |> Enum.map(&task_async(&1))
       |> Enum.map(&Task.await(&1, task_options.timeout))
     end)
-    |> List.flatten
+    |> List.foldr([], fn a,b -> a ++ b end)
   end
 
   defp task_async(fun) do

--- a/lib/paratize/chunk.ex
+++ b/lib/paratize/chunk.ex
@@ -31,7 +31,7 @@ defmodule Paratize.Chunk do
       |> Enum.map(&task_async(&1))
       |> Enum.map(&Task.await(&1, task_options.timeout))
     end)
-    |> List.foldr([], fn a,b -> a ++ b end)
+    |> Enum.reduce(fn a,b -> b ++ a end)
   end
 
   defp task_async(fun) do

--- a/lib/paratize/chunk.ex
+++ b/lib/paratize/chunk.ex
@@ -31,7 +31,7 @@ defmodule Paratize.Chunk do
       |> Enum.map(&task_async(&1))
       |> Enum.map(&Task.await(&1, task_options.timeout))
     end)
-    |> Enum.reduce(fn a,b -> b ++ a end)
+    |> Enum.reduce(fn result, acc -> acc ++ result end)
   end
 
   defp task_async(fun) do

--- a/test/paratize/base_test_common.exs
+++ b/test/paratize/base_test_common.exs
@@ -6,8 +6,6 @@ defmodule Paratize.BaseTest.Common do
 
       def test_impl, do: unquote(test_impl)
 
-
-
       test "parallel_each/3 is able to execute the task in parallel and returns :ok." do
         args = [1,2,3,4,5]
         {:ok, store_pid} = Agent.start_link(fn-> [] end)

--- a/test/paratize/base_test_common.exs
+++ b/test/paratize/base_test_common.exs
@@ -6,13 +6,16 @@ defmodule Paratize.BaseTest.Common do
 
       def test_impl, do: unquote(test_impl)
 
+      def deep_multiply_by_two(arg) when is_list(arg), do: Enum.map(arg, &deep_multiply_by_two(&1))
+      def deep_multiply_by_two(arg), do: arg * 2
+
       test "parallel_each/3 is able to execute the task in parallel and returns :ok." do
-        args = [1,2,3,4,5]
+        args = [1,2,3,4,5,[6,7,[8]]]
         {:ok, store_pid} = Agent.start_link(fn-> [] end)
         worker_fun = fn(arg) ->
           Agent.update(store_pid, fn(item) -> [arg|item] end)
           :timer.sleep(100)
-          arg * 2
+          deep_multiply_by_two(arg)
         end
 
         {time, result} = :timer.tc fn ->
@@ -21,18 +24,18 @@ defmodule Paratize.BaseTest.Common do
 
         assert MapSet.equal?(
           Agent.get(store_pid, &(&1)) |> Enum.into(MapSet.new),
-          [5,4,3,2,1] |> Enum.into(MapSet.new))
+          [[6,7,[8]],5,4,3,2,1] |> Enum.into(MapSet.new))
         assert result == :ok
         assert div(time, 1000) in 300..500
       end
 
       test "parallel_map/3 is able to execute the task in parallel and return the list of results" do
-        args = [1,2,3,4,5]
+        args = [1,2,3,4,5,[6,7,[8]]]
         {:ok, store_pid} = Agent.start_link(fn-> [] end)
         worker_fun = fn(arg) ->
           Agent.update(store_pid, fn(item) -> [arg|item] end)
           :timer.sleep(100)
-          arg * 2
+          deep_multiply_by_two(arg)
         end
 
         {time, result} = :timer.tc fn ->
@@ -41,26 +44,10 @@ defmodule Paratize.BaseTest.Common do
 
         assert MapSet.equal?(
           Agent.get(store_pid, &(&1)) |> Enum.into(MapSet.new),
-          [5,4,3,2,1] |> Enum.into(MapSet.new))
-        assert result == [2,4,6,8,10]
+          [[6,7,[8]],5,4,3,2,1] |> Enum.into(MapSet.new))
+        assert result == [2,4,6,8,10,[12,14,[16]]]
         assert div(time, 1000) in 300..500
       end
-
-      test "parallel_map/3 maintains structure of input/output" do
-        args = [1,[2],3,[4,5]]
-
-        worker_fun = fn 
-          (arg) when is_list(arg) -> arg ++ arg
-          (arg) when is_integer(arg) -> arg * 2
-        end
-
-        {time, result} = :timer.tc fn ->
-          args |> test_impl().parallel_map(worker_fun)
-        end
-
-        assert result == [2,[2,2],6,[4,5,4,5]]
-      end
-
     end
   end
 

--- a/test/paratize/base_test_common.exs
+++ b/test/paratize/base_test_common.exs
@@ -6,6 +6,8 @@ defmodule Paratize.BaseTest.Common do
 
       def test_impl, do: unquote(test_impl)
 
+
+
       test "parallel_each/3 is able to execute the task in parallel and returns :ok." do
         args = [1,2,3,4,5]
         {:ok, store_pid} = Agent.start_link(fn-> [] end)
@@ -44,6 +46,33 @@ defmodule Paratize.BaseTest.Common do
           [5,4,3,2,1] |> Enum.into(MapSet.new))
         assert result == [2,4,6,8,10]
         assert div(time, 1000) in 300..500
+      end
+
+      test "parallel_map does not over flatten arrays 1." do
+        fn1 = fn a -> [a] end
+        args1 = [1,2,3,4,5]
+        result1 = args1 |> test_impl().parallel_map(fn1, %Paratize.TaskOptions{size: 2})
+
+        assert MapSet.equal?(
+          args1 |> Enum.map(fn1) |> Enum.into(MapSet.new),
+          result1 |> Enum.into(MapSet.new))
+
+        fn2 = fn a -> a ++ 1 end
+        args2 = result1
+        result2 = args2 |> test_impl().parallel_map(fn2, %Paratize.TaskOptions{size: 2})
+
+        assert MapSet.equal?(
+          args2 |> Enum.map(fn2) |> Enum.into(MapSet.new),
+          result2 |> Enum.into(MapSet.new))
+
+        fn3 = fn a -> a ++ 1 end
+        args3 = [[1,2,3,4,5]]
+        result3 = args3 |> test_impl().parallel_map(fn3, %Paratize.TaskOptions{size: 2})
+
+        assert MapSet.equal?(
+          args3 |> Enum.map(fn3) |> Enum.into(MapSet.new),
+          result3 |> Enum.into(MapSet.new))
+
       end
     end
   end


### PR DESCRIPTION
List.flatten over flattens array, making parallel_map not work as a replacement for regular map with deeply nested array.